### PR TITLE
This PR adds Oil temperature data to MQB clusters

### DIFF
--- a/CarCluster/src/Clusters/VW_MQB/VWMQBCluster.cpp
+++ b/CarCluster/src/Clusters/VW_MQB/VWMQBCluster.cpp
@@ -93,7 +93,7 @@ void VWMQBCluster::updateWithGame(GameState& game) {
     sendESP21(mapSpeed(game));
     sendTSK07();
     sendLhEPS01();
-    sendMotor(mapRPM(game), mapCoolantTemperature(game));
+    sendMotor(mapRPM(game), mapCoolantTemperature(game), game.oilTemperature);
     sendESP24();
     sendGear(mapGenericGearToLocalGear(game.gear));
     sendAirbag01();
@@ -261,7 +261,7 @@ void VWMQBCluster::sendLhEPS01() {
   CAN.sendMsgBuf(LH_EPS_01_ID, 0, 8, lhEps01Buf);
 }
 
-void VWMQBCluster::sendMotor(int rpm, int coolantTemperature) {
+void VWMQBCluster::sendMotor(int rpm, int coolantTemperature, int oilTemperature) {
   //
   // Motor_Code_01
   //
@@ -289,7 +289,8 @@ void VWMQBCluster::sendMotor(int rpm, int coolantTemperature) {
 
   CAN.sendMsgBuf(MOTOR_04_ID, 0, 8, motor04Buf);
 
-  // CAN.sendMsgBuf(MOTOR_07_ID, 0, 8, motor07Buf); // TODO: REMOVE
+  motor07Buf[2] = 60 + constrain(oilTemperature, 49, 193);
+  CAN.sendMsgBuf(MOTOR_07_ID, 0, 8, motor07Buf);
 
   uint8_t mappedVal = map(coolantTemperature, 50, 130, 0x80, 0xED);
   motor09Buf[0] = mappedVal;

--- a/CarCluster/src/Clusters/VW_MQB/VWMQBCluster.h
+++ b/CarCluster/src/Clusters/VW_MQB/VWMQBCluster.h
@@ -134,7 +134,7 @@ class VWMQBCluster: public Cluster {
     void sendESP21(int speed);
     void sendTSK07();
     void sendLhEPS01();
-    void sendMotor(int rpm, int coolantTemperature);
+    void sendMotor(int rpm, int coolantTemperature, int oilTemperature);
     void sendESP24();
     void sendGear(uint8_t gear);
     void sendAirbag01();

--- a/CarCluster/src/Games/GameSimulation.h
+++ b/CarCluster/src/Games/GameSimulation.h
@@ -111,6 +111,7 @@ class GameState {
   enum GearState gear = GearState_Auto_P;            // The gear that the car is in
   uint8_t backlightBrightness = 100;                 // Backlight brightness 0-99
   int coolantTemperature = 100;                      // Coolant temperature 50-130C
+  int oilTemperature = 80;                           // Oil temperature 50-192C
   bool ignition = true;                              // Ignition status (set to false for accessory)
   int fuelQuantity = 100;                            // Amount of fuel
   int outdoorTemperature = 20;                       // Outdoor temperature (from -50 to 50)

--- a/CarCluster/src/Other/WebDashboard.cpp
+++ b/CarCluster/src/Other/WebDashboard.cpp
@@ -26,6 +26,7 @@ WebDashboard::WebDashboard(GameState &game, int serverPort, unsigned long webDas
   gearCard(&dashboard, SLIDER_CARD, "Selected gear", "", 1, 15),
   backlightCard(&dashboard, SLIDER_CARD, "Backlight brightness", "%", 0, 100),
   coolantTemperatureCard(&dashboard, SLIDER_CARD, "Coolant temperature", "C", gameState.configuration.minimumCoolantTemperature, gameState.configuration.maximumCoolantTemperature),
+  oilTemperatureCard(&dashboard, SLIDER_CARD, "Oil Temperature", "C", 49, 193),
   handbrakeCard(&dashboard, BUTTON_CARD, "Handbrake"),
   button1Card(&dashboard, BUTTON_CARD, "Steering button 1"),
   button2Card(&dashboard, BUTTON_CARD, "Steering button 2"),
@@ -126,6 +127,12 @@ void WebDashboard::begin() {
   coolantTemperatureCard.attachCallback([&](int value) {
     gameState.coolantTemperature = value;
     coolantTemperatureCard.update(value);
+    dashboard.sendUpdates();
+  });
+
+  oilTemperatureCard.attachCallback([&](int value) {
+    gameState.oilTemperature = value;
+    oilTemperatureCard.update(value);
     dashboard.sendUpdates();
   });
 
@@ -249,6 +256,7 @@ void WebDashboard::update() {
     gearCard.update(gameState.gear);
     backlightCard.update(gameState.backlightBrightness);
     coolantTemperatureCard.update(gameState.coolantTemperature);
+    oilTemperatureCard.update(gameState.oilTemperature);
     handbrakeCard.update(gameState.handbrake);
     ignitionCard.update(gameState.ignition);
     driveModeCard.update(gameState.driveMode);

--- a/CarCluster/src/Other/WebDashboard.h
+++ b/CarCluster/src/Other/WebDashboard.h
@@ -53,6 +53,7 @@ class WebDashboard {
     Card gearCard;
     Card backlightCard;
     Card coolantTemperatureCard;
+    Card oilTemperatureCard;
     Card handbrakeCard;
     Card button1Card;
     Card button2Card;


### PR DESCRIPTION
based on @adam-ht's work

notes: values below 50c show up as `---C` on the cluster, and values above 192c make the panel disappear until a smaller value is sent.
constrain() is used to avoid an overflow due to the offset