### PR TITLE
Adding PQ46 backlight brightness

### DIFF
--- a/CarCluster/src/Clusters/VW_PQ46/VWPQ46Cluster.cpp
+++ b/CarCluster/src/Clusters/VW_PQ46/VWPQ46Cluster.cpp
@@ -105,7 +105,8 @@ void VWPQ46Cluster::updateWithGame(GameState& game) {
     // scheduler, but for now this seems to work.
 
     sendImmobilizer();
-    sendIndicators(game.leftTurningIndicator, game.rightTurningIndicator, game.turningIndicatorsBlinking, game.mainLights, game.highBeam, game.frontFogLight, game.rearFogLight, game.batteryLight, false, game.doorOpen, game.backlightBrightness);
+    sendIndicators(game.leftTurningIndicator, game.rightTurningIndicator, game.turningIndicatorsBlinking, game.mainLights, game.highBeam, game.frontFogLight, game.rearFogLight, game.batteryLight, false, game.doorOpen);
+    sendBacklightBrightness(game.backlightBrightness);
     sendDieselEngine();
     sendRPM(mapRPM(game));
     sendSpeed(mapSpeed(game), false, game.offroadLight, game.absLight);
@@ -141,7 +142,7 @@ void VWPQ46Cluster::sendImmobilizer() {
   CAN.sendMsgBuf(IMMOBILIZER_ID, 0, 8, immobilizerBuffer);
 }
 
-void VWPQ46Cluster::sendIndicators(boolean leftBlinker, boolean rightBlinker, boolean blinkersBlinking, boolean daylightBeam, boolean highBeam, boolean frontFogLight, boolean rearFogLight, boolean batteryWarning, boolean trunkOpen, boolean doorOpen, int brightness) {
+void VWPQ46Cluster::sendIndicators(boolean leftBlinker, boolean rightBlinker, boolean blinkersBlinking, boolean daylightBeam, boolean highBeam, boolean frontFogLight, boolean rearFogLight, boolean batteryWarning, boolean trunkOpen, boolean doorOpen) {
   uint8_t temp_turning_lights = 0 | leftBlinker | (rightBlinker << 1);
   if (blinkersBlinking == true) {
     turning_lights_counter = turning_lights_counter + 1;
@@ -171,6 +172,13 @@ void VWPQ46Cluster::sendIndicators(boolean leftBlinker, boolean rightBlinker, bo
   lightsBuffer[2] = temp_turning_lights;
   //CanSend(0x531, speed, 0x00, temp_turning_lights, 0x00, 0x00, 0x00, 0x00, 0x00);
   CAN.sendMsgBuf(LIGHTS_ID, 0, 8, lightsBuffer);
+}
+
+void VWPQ46Cluster::sendBacklightBrightness(uint8_t brightness) {
+  dimmungBuffer[0] = brightness & 0x7F; // Screen brightness
+  dimmungBuffer[1] = brightness & 0x7F; // Switch brightness
+  CAN.sendMsgBuf(DIMMUNG_ID, 0, 3, dimmungBuffer);
+  // Screen and switch brightness set the same.
 }
 
 void VWPQ46Cluster::sendDieselEngine() {

--- a/CarCluster/src/Clusters/VW_PQ46/VWPQ46Cluster.h
+++ b/CarCluster/src/Clusters/VW_PQ46/VWPQ46Cluster.h
@@ -23,6 +23,7 @@
 #define AIRBAG_ID 0x050 // Airbag
 #define GEAR_ID 0x540 // Gear shifter
 #define CRUISE_CONTROL_ID 0x288 // Cruise control
+#define DIMMUNG_ID  0x635 // Backlight
 
 class VWPQ46Cluster: public Cluster {
   public:
@@ -75,10 +76,12 @@ class VWPQ46Cluster: public Cluster {
                   airbagBuffer[8] = { 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },
                   gearShifterBuffer[8] = { 0x90, 0x00, 0xFF, 0x00, 0xFF, 0x00, 0x02, 0x00 },
                   cruiseControlBuffer[8] = { 0x8A, 0xB4, 0x30, 0x00, 0x51, 0x46, 0x9B, 0x09 },
+                  dimmungBuffer[3] = { 0x80, 0x80, 0x00 },
                   testBuff[8] = { 0x04, 0x06, 0x40, 0x00, 0xFF, 0xFE, 0x69, 0x2C };
 
     void sendImmobilizer();
-    void sendIndicators(boolean leftBlinker, boolean rightBlinker, boolean blinkersBlinking, boolean daylightBeam, boolean highBeam, boolean frontFogLight, boolean rearFogLight, boolean batteryWarning, boolean trunkOpen, boolean doorOpen, int brightness);
+    void sendIndicators(boolean leftBlinker, boolean rightBlinker, boolean blinkersBlinking, boolean daylightBeam, boolean highBeam, boolean frontFogLight, boolean rearFogLight, boolean batteryWarning, boolean trunkOpen, boolean doorOpen);
+    void sendBacklightBrightness(uint8_t brightness);
     void sendDieselEngine();
     void sendRPM(int rpm);
     void sendSpeed(int speed, boolean tpmsLight, boolean espLight, boolean absLight);


### PR DESCRIPTION
1. Removed backlight brightness functionality from sendIndicators(...) in VWPQ46Cluster
2. Created a new function, sendBacklightBrightness(uint8_t brightness), based on the MQB implementation, with updated bitfields. 
3. Updated the corresponding header file accordingly.
4. Tested on hardware – the cluster backlight now works as expected (screenshot attached).

This is my first PR, and I appreciate any feedback or suggestions for improvement. :) 
![image](https://github.com/user-attachments/assets/57a2c969-ee1c-4353-bfa3-0be861403e1d)
