### PR TITLE
feat(mqb): cluster clock

### DIFF
--- a/CarCluster/CarCluster.ino
+++ b/CarCluster/CarCluster.ino
@@ -306,6 +306,9 @@ START_INIT2:
 }
 
 void loop() {
+  // Free-running software clock (no RTC): ticks from millis(); external time sets just correct it.
+  game.clock.tick();
+
   // Update the cluster with current state of the game
   cluster.updateWithGame(game);
 
@@ -375,6 +378,16 @@ void readSerialJson() {
         // Used to decode custom protocol from Simhub in the following format:
         // {"action":10, "spe":54, "gea":"2", "rpm":3590, "mrp":7999, "lft":0, "rit":0, "oit":0, "pau":0, "run":0, "fue":0, "hnb":0, "abs":0, "tra":0}
         simhubGame.decodeSerialData(doc);
+      } else if (action == 1) {
+        // Initialise / set the cluster clock (VW MQB). Self-contained: only touches the
+        // clock fields, each optional/non-destructive. The free-running software clock
+        // then keeps ticking on its own.
+        // Example: {"action":1, "chh":20, "cmm":30, "cyy":25, "cmo":6, "cdd":12}
+        game.clock.hour   = doc["chh"] | game.clock.hour;
+        game.clock.minute = doc["cmm"] | game.clock.minute;
+        game.clock.year   = doc["cyy"] | game.clock.year;
+        game.clock.month  = doc["cmo"] | game.clock.month;
+        game.clock.day    = doc["cdd"] | game.clock.day;
       }
 
       //Reset for the next message

--- a/CarCluster/src/Clusters/VW_MQB/VWMQBCluster.cpp
+++ b/CarCluster/src/Clusters/VW_MQB/VWMQBCluster.cpp
@@ -120,6 +120,8 @@ void VWMQBCluster::updateWithGame(GameState& game) {
     sendOtherLights();
     sendDoorStatus(game.doorOpen);
     sendOutdoorTemperature(game.outdoorTemperature);
+    sendTime(game.clock.hour, game.clock.minute);
+    sendDate(game.clock.year, game.clock.month, game.clock.day);
 
     if (game.buttonEventToProcess != 0) {
       sendSteeringWheelControls(game.buttonEventToProcess + 3);
@@ -519,6 +521,21 @@ void VWMQBCluster::sendOutdoorTemperature(int temperature) {
   outdoorTempBuff[0] = (50 + temperature) << 1; // Bit shift 1 to the left since 0.5 is the first bit
 
   CAN.sendMsgBuf(OUTDOOR_TEMP_ID, 0, 8, outdoorTempBuff);
+}
+
+// Time/date are BAP messages on the EXTENDED 29-bit id 0x17331100 (normally radio->cluster).
+// Values are plain binary (e.g. hour 20 = 0x14), not BCD. 2nd sendMsgBuf arg = 1 selects extended id.
+void VWMQBCluster::sendTime(uint8_t hour, uint8_t minute) {
+  timeBuff[2] = hour;
+  timeBuff[3] = minute;
+  CAN.sendMsgBuf(DATE_ID, 1, 5, timeBuff);
+}
+
+void VWMQBCluster::sendDate(uint8_t year, uint8_t month, uint8_t day) {
+  dateBuff[2] = year;  // 2-digit year, e.g. 25 for 2025
+  dateBuff[3] = month;
+  dateBuff[4] = day;
+  CAN.sendMsgBuf(DATE_ID, 1, 5, dateBuff);
 }
 
 void VWMQBCluster::updateTestBuffer(uint8_t val0, uint8_t val1, uint8_t val2, uint8_t val3, uint8_t val4, uint8_t val5, uint8_t val6, uint8_t val7) {

--- a/CarCluster/src/Clusters/VW_MQB/VWMQBCluster.h
+++ b/CarCluster/src/Clusters/VW_MQB/VWMQBCluster.h
@@ -48,7 +48,7 @@
 #define LICHT_ANF_ID 0x3D5 // Lights... somewhere
 #define DOOR_STATUS_ID 0x583 // Door status
 #define OUTDOOR_TEMP_ID 0x5e1 // Outdoor temperature
-#define DATE_ID 0x17331110
+#define DATE_ID 0x17331100 // BAP time/date, sent as a 29-bit EXTENDED id (radio->cluster)
 // WARNING: NEVER TOUCH ADDRESS 0x6B4 !!!!! This is part of component protection/VIN
 
 class VWMQBCluster: public Cluster {
@@ -126,7 +126,9 @@ class VWMQBCluster: public Cluster {
                   outdoorTempBuff[8] = { 0x9A, 0x2A, 0x00, 0x60, 0xFE, 0x00, 0x00, 0x00 },
                   lichtAnfBuff[8] = { 0x00, 0x04, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00 },
                   lichtHintenBuff[8] = { 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },
-                  testBuff[8] = { 0x04, 0x06, 0x40, 0x00, 0xFF, 0xFE, 0x69, 0x2C };
+                  testBuff[8] = { 0x04, 0x06, 0x40, 0x00, 0xFF, 0xFE, 0x69, 0x2C },
+                  timeBuff[5] = { 0x24, 0x51, 0x00, 0x00, 0x00 },  // [2]=hour [3]=minute [4]=second
+                  dateBuff[5] = { 0x24, 0x50, 0x00, 0x00, 0x00 };  // [2]=year(2-digit) [3]=month [4]=day
 
     void sendIgnitionStatus(boolean ignition);
     void sendBacklightBrightness(uint8_t brightness);
@@ -146,7 +148,9 @@ class VWMQBCluster: public Cluster {
     void sendDoorStatus(boolean doorOpen);
     void sendOutdoorTemperature(int temperature);
     void sendOtherLights();
-    
+    void sendTime(uint8_t hour, uint8_t minute);
+    void sendDate(uint8_t year, uint8_t month, uint8_t day);
+
     void setFuel(GameState& game);
     uint8_t mapGenericGearToLocalGear(GearState inputGear);
     int mapSpeed(GameState& game);

--- a/CarCluster/src/Games/Clock.h
+++ b/CarCluster/src/Games/Clock.h
@@ -1,0 +1,61 @@
+// ####################################################################################################################
+//
+// Clock - free-running software clock for the instrument cluster (no RTC required).
+// Ticks from millis(); correct it by writing the public fields (e.g. from a time set
+// over serial). Values are plain (not BCD); year is 2-digit (e.g. 25 = 2025).
+//
+// ####################################################################################################################
+
+#ifndef CARCLUSTER_CLOCK
+#define CARCLUSTER_CLOCK
+
+#include "Arduino.h"
+
+class Clock {
+  public:
+    uint8_t hour = 12;    // 0-23
+    uint8_t minute = 0;   // 0-59
+    uint8_t second = 0;   // 0-59 (most clusters display only HH:MM)
+    uint8_t year = 25;    // 2-digit year, e.g. 25 = 2025
+    uint8_t month = 1;    // 1-12
+    uint8_t day = 1;      // 1-31
+
+    // Call every main loop iteration. Advances the time/date from elapsed millis(),
+    // so the clock keeps running without an RTC. Correct it by writing the fields above.
+    void tick() {
+      unsigned long now = millis();
+      if (lastTickMs == 0) { lastTickMs = now; return; }
+      unsigned long elapsed = now - lastTickMs;          // unsigned: survives millis() wrap
+      if (elapsed < 1000) return;
+      unsigned long secs = elapsed / 1000;
+      lastTickMs += secs * 1000;                         // keep sub-second remainder
+      if (secs > 86400) secs = 86400;                    // guard against pathological catch-up
+      while (secs--) { tickOneSecond(); }
+    }
+
+  private:
+    unsigned long lastTickMs = 0;                        // millis() of last 1s tick (0 = not seeded)
+
+    void tickOneSecond() {
+      if (++second < 60) return;
+      second = 0;
+      if (++minute < 60) return;
+      minute = 0;
+      if (++hour < 24) return;
+      hour = 0;
+      if (++day <= daysInMonth(month, year)) return;
+      day = 1;
+      if (++month <= 12) return;
+      month = 1;
+      year = (uint8_t)((year + 1) % 100);
+    }
+
+    static uint8_t daysInMonth(uint8_t m, uint8_t y) {
+      static const uint8_t d[12] = {31,28,31,30,31,30,31,31,30,31,30,31};
+      if (m < 1 || m > 12) return 31;
+      if (m == 2 && ((2000 + y) % 4 == 0)) return 29;    // valid for years 2000-2099
+      return d[m - 1];
+    }
+};
+
+#endif

--- a/CarCluster/src/Games/GameSimulation.h
+++ b/CarCluster/src/Games/GameSimulation.h
@@ -8,6 +8,7 @@
 #define GAME_SIMULATION
 
 #include "Arduino.h"
+#include "Clock.h"
 
 struct ClusterConfiguration {
   float speedCorrectionFactor = 1.00;   // Calibration of speed gauge
@@ -129,6 +130,10 @@ class GameState {
   uint8_t driveMode = 3;                             // Current drive mode for BMW: 1= Traction, 2= Comfort+, 4= Sport, 5= Sport+, 6= DSC off, 7= Eco pro 
   bool absLight = false;                             // Shows ABS Signal on dashboard
   bool batteryLight = false;                         // Show Battery Warning.
+
+  // Free-running cluster clock. Ticks on its own (call clock.tick() each loop);
+  // correct it by writing clock.hour/minute/... e.g. from a serial time set.
+  Clock clock;
 
   // Other stuff
   int buttonEventToProcess = 0;                      // Certain clusters have buttons that can perform actions. Set this to activate them - values are cluster dependent


### PR DESCRIPTION
Implementation of #29 discussion around time and date on MQB clusters.

Apart from CAN frame for date/time this PR also includes:
- ~free-running tick so clock will advance itself~
- possibility to set date/time by serial, e.g. `{"action":1, "chh":20, "cmm":30, "cyy":25, "cmo":6, "cdd":12}` will set `20:30 2025-06-12`; I've chosen action 1 to not collide with action 10

By default datetime is set to 12:00 2025-01-01. It will automatically start advancing.

Tested on Leon 5F (MQB) cluster. Ignore broken glass - apart from that cluster works fine! 😄

Initial state
<img width="5712" height="3213" alt="IMG_2192" src="https://github.com/user-attachments/assets/39222653-a79b-4b26-b0aa-a9fe7b8e5b7b" />

After sending `{"action":1, "chh":15, "cmm":0, "cyy":26, "cmo":6, "cdd":13}` though serial
<img width="5712" height="3213" alt="IMG_2193" src="https://github.com/user-attachments/assets/1e2ebaba-ee5f-48b6-ae62-616b9f4dae70" />

After 1 minute
<img width="4032" height="2268" alt="IMG_2194" src="https://github.com/user-attachments/assets/47399c43-fc4a-457f-b3a3-8f4a72158b01" />
